### PR TITLE
improve consistency of histogram presentation

### DIFF
--- a/components/page.js
+++ b/components/page.js
@@ -54,6 +54,7 @@ export default class extends Component {
     const xmax = Math.max(...[...elos, ...teamElos].filter(Boolean)).clamp(0, Infinity);
 
     const xbins = {start: 0, end: 3500,size: 10}; // each bin covers 10 elo points
+    const soloPopSize = elos.filter(Boolean).length;
 
     // Random Map Histogram
     let traceRandomMap = {
@@ -70,8 +71,8 @@ export default class extends Component {
         },
       },
       showlegend: true,
-      name: `N = ${elos.filter(Boolean).length.toLocaleString()}`,
-      autobinx:false,
+      name: `N = ${soloPopSize.toLocaleString()}`,
+      autobinx: soloPopSize < 1000, // Deathmatch lacks enough samples to let manual binning look good
       xbins,
       hovermode: "x unified",
       hoveron: "points+fills",
@@ -132,6 +133,7 @@ export default class extends Component {
     for (let i = 0; i < histogramArray.length; i++) {
       teamRandomMapScores[i] = histogramArray[i][2];
     }
+    const teamPopSize = teamElos.filter(Boolean).length;
     let traceTeamRandomMap = {
       x: teamElos,
       type: "histogram",
@@ -139,8 +141,8 @@ export default class extends Component {
         color: DEFAULT_COLOR,
       },
       showlegend: true,
-      name: `N = ${teamElos.filter(Boolean).length.toLocaleString()}`,
-      autobinx:false,
+      name: `N = ${teamPopSize.toLocaleString()}`,
+      autobinx: teamPopSize < 1000,
       xbins,
       hovertemplate:
         "# of Players: %{y}<br>Rating Range: %{x}<br>Percentile: %{text}<extra></extra>",

--- a/components/page.js
+++ b/components/page.js
@@ -67,6 +67,8 @@ export default class extends Component {
           color: "red",
         },
       },
+      showlegend: true,
+      name: `N = ${elos.filter(Boolean).length.toLocaleString()}`,
       hovermode: "x unified",
       hoveron: "points+fills",
     };
@@ -106,6 +108,7 @@ export default class extends Component {
       },
       marker: { color: DEFAULT_COLOR },
       hovermode: "false",
+      legend: {x: 1, y: 1, xanchor: 'right'},
     };
     let dataRandomMap = [traceRandomMap];
     let randomMapPlot = Plotly.newPlot(
@@ -131,6 +134,8 @@ export default class extends Component {
       marker: {
         color: DEFAULT_COLOR,
       },
+      showlegend: true,
+      name: `N = ${teamElos.filter(Boolean).length.toLocaleString()}`,
       hovertemplate:
         "# of Players: %{y}<br>Rating Range: %{x}<br>Percentile: %{text}<extra></extra>",
     };
@@ -168,6 +173,7 @@ export default class extends Component {
         },
         fixedrange: true,
       },
+      legend: {x: 1, y: 1, xanchor: 'right'},
     };
     let dataTeamRandomMap = [traceTeamRandomMap];
     let teamRandomMapPlot = Plotly.newPlot(

--- a/components/page.js
+++ b/components/page.js
@@ -45,12 +45,17 @@ export default class extends Component {
     let dataSet = new Data(this.props.data);
     let histogramArray = []; // JSON.parse(this.props.histogram);
     let timestamp = this.props.timestamp ? this.props.timestamp : 0;
-    let xmin = this.props.xmin;
-    let xmax = this.props.xmax;
+
+    const elos = dataSet.getRatingsArray(this.props.dataLabelOne);
+    const teamElos = dataSet.getRatingsArray(this.props.dataLabelTwo);
+
+    // Share xmin and xmas for all 3 graphs
+    const xmin = Math.min(...[...elos, ...teamElos].filter(Boolean)).clamp(0, Infinity);
+    const xmax = Math.max(...[...elos, ...teamElos].filter(Boolean)).clamp(0, Infinity);
 
     // Random Map Histogram
     let traceRandomMap = {
-      x: dataSet.getRatingsArray(this.props.dataLabelOne),
+      x: elos,
       type: "histogram",
       marker: {
         color: DEFAULT_COLOR,
@@ -85,11 +90,7 @@ export default class extends Component {
             color: AXIS_FONT_COLOR,
           },
         },
-        range: [
-          // TODO: this can be done in one pass
-          Math.min(...dataSet.getRatingsArray(this.props.dataLabelOne)),
-          Math.min(...dataSet.getRatingsArray(this.props.dataLabelOne)),
-        ],
+        range: [xmin, xmax],
         fixedrange: true,
       },
       yaxis: {
@@ -125,7 +126,7 @@ export default class extends Component {
       teamRandomMapScores[i] = histogramArray[i][2];
     }
     let traceTeamRandomMap = {
-      x: dataSet.getRatingsArray(this.props.dataLabelTwo),
+      x: teamElos,
       type: "histogram",
       marker: {
         color: DEFAULT_COLOR,
@@ -153,11 +154,7 @@ export default class extends Component {
             color: AXIS_FONT_COLOR,
           },
         },
-        range: [
-          // TODO: this can be done in one pass
-          Math.min(...dataSet.getRatingsArray(this.props.dataLabelTwo)),
-          Math.min(...dataSet.getRatingsArray(this.props.dataLabelTwo)),
-        ],
+        range: [xmin, xmax],
         fixedrange: true,
       },
       yaxis: {
@@ -187,14 +184,14 @@ export default class extends Component {
 
     // TODO: move this into data?
     let fullNames = dataSet.getAllNames();
-    let fullX = dataSet.getRatingsArray(this.props.dataLabelOne);
-    let fullY = dataSet.getRatingsArray(this.props.dataLabelTwo);
+    let fullX = elos;
+    let fullY = teamElos;
     let filteredNames = [];
     let filteredX = [];
     let filteredY = [];
     for (
       let i = 0;
-      i < dataSet.getRatingsArray(this.props.dataLabelOne).length;
+      i < elos.length;
       i++
     ) {
       if (fullX[i] !== undefined && fullY[i] !== undefined) {

--- a/components/page.js
+++ b/components/page.js
@@ -53,6 +53,8 @@ export default class extends Component {
     const xmin = Math.min(...[...elos, ...teamElos].filter(Boolean)).clamp(0, Infinity);
     const xmax = Math.max(...[...elos, ...teamElos].filter(Boolean)).clamp(0, Infinity);
 
+    const xbins = {start: 0, end: 3500,size: 10}; // each bin covers 10 elo points
+
     // Random Map Histogram
     let traceRandomMap = {
       x: elos,
@@ -69,6 +71,8 @@ export default class extends Component {
       },
       showlegend: true,
       name: `N = ${elos.filter(Boolean).length.toLocaleString()}`,
+      autobinx:false,
+      xbins,
       hovermode: "x unified",
       hoveron: "points+fills",
     };
@@ -136,6 +140,8 @@ export default class extends Component {
       },
       showlegend: true,
       name: `N = ${teamElos.filter(Boolean).length.toLocaleString()}`,
+      autobinx:false,
+      xbins,
       hovertemplate:
         "# of Players: %{y}<br>Rating Range: %{x}<br>Percentile: %{text}<extra></extra>",
     };

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,9 @@
   display: none;
 }
 
+/* hide legend color chip */
+.traces .legendsymbols { display: none; }
+
 .loading-spinner {
   width: 40px;
   height: 40px;


### PR DESCRIPTION
Now that the team [elo calculation has been fixed](https://www.ageofempires.com/news/updates-to-ranked-team-game-elo-calculation/)... i think it'd be better to align a few presentational details of the 1v1 and team plots.

in short:

- share an x axis across all 3 plots 
   - the team RM xaxis starts in the negatives (thanks to two players... shrug)
   - easier to compare the two elos
- show size of population for each histogram
- use same histogram binning for the solo and team plots

screenshots of before/after:

![elos-before-after](https://user-images.githubusercontent.com/39191/181841587-927dc77e-5f88-49f9-91d2-175a22545daf.png)

and with the marker:

![elos-marker-before-after](https://user-images.githubusercontent.com/39191/181842374-fa4e5f2d-2597-4e77-b121-f3808c3effbb.png)

